### PR TITLE
Refactor src/test/esp -> src/test/esptests

### DIFF
--- a/src/test/scala/esptests/AcceleratorSpec.scala
+++ b/src/test/scala/esptests/AcceleratorSpec.scala
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package espTests
+package esptests
 
 import chisel3._
 import chisel3.util.Counter

--- a/src/test/scala/esptests/AcceleratorWrapperSpec.scala
+++ b/src/test/scala/esptests/AcceleratorWrapperSpec.scala
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package espTests
+package esptests
 
 import chisel3._
 import firrtl.{ir => fir}


### PR DESCRIPTION
This fixes an incorrect directory name (which should reflect the package).
This changes the packaged name for tests from "espTests" to "esptests".
The latter, lowercase name is preferred for Scala package names.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@ibm.com>