### PR TITLE
Add explicit CounterAccelerator

### DIFF
--- a/src/main/scala/esp/examples/CounterAccelerator.scala
+++ b/src/main/scala/esp/examples/CounterAccelerator.scala
@@ -1,0 +1,33 @@
+// Copyright 2018 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esp.examples
+
+import chisel3._
+import chisel3.util.Counter
+
+import esp.Accelerator
+
+/** An ESP accelerator that is done a parameterized number of clock ticks in the future
+  * @param ticks the number of clock ticks until done
+  */
+class CounterAccelerator(val ticks: Int) extends Accelerator {
+  val enabled = RegInit(false.B)
+
+  val (_, fire) = Counter(enabled, ticks)
+  io.done := fire
+
+  when (io.conf.valid) { enabled := true.B  }
+  when (fire)          { enabled := false.B }
+}

--- a/src/test/scala/esptests/examples/CounterAcceleratorSpec.scala
+++ b/src/test/scala/esptests/examples/CounterAcceleratorSpec.scala
@@ -14,29 +14,15 @@
 
 package esptests
 
-import chisel3._
-import chisel3.util.Counter
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
 import esp.Accelerator
+import esp.examples.CounterAccelerator
 
-/** An ESP accelerator that says it's done a fixed number of cycles after it's enabled
-  * @param ticks the number of cycles to count
+/** A test that the [[CounterAccelerator]] asserts it's done when it should
+  * @param dut a [[CounterAccelerator]]
   */
-class TimerAccelerator(val ticks: Int) extends Accelerator {
-  val enabled = RegInit(false.B)
-
-  val (_, fire) = Counter(enabled, ticks)
-  io.done := fire
-
-  when (io.conf.valid) { enabled := true.B  }
-  when (fire)          { enabled := false.B }
-}
-
-/** A test that the TimerAccelerator asserts it's done when it should
-  * @param dut a [[TimerAccelerator]]
-  */
-class TimerAcceleratorTester(dut: TimerAccelerator) extends PeekPokeTester(dut) {
+class CounterAcceleratorTester(dut: CounterAccelerator) extends PeekPokeTester(dut) {
   def reset(): Unit = Seq(dut.io.conf.valid,
                           dut.io.dma.readControl.ready,
                           dut.io.dma.writeControl.ready,
@@ -62,10 +48,10 @@ class TimerAcceleratorTester(dut: TimerAccelerator) extends PeekPokeTester(dut) 
 
 class AcceleratorSpec extends ChiselFlatSpec {
 
-  behavior of "A simple timer ESP Accelerator"
+  behavior of "CounterAccelerator"
 
-  it should "report it's done after 42 cycles" in {
-    Driver(() => new TimerAccelerator(42), "firrtl")(dut => new TimerAcceleratorTester(dut)) should be (true)
+  it should "assert done after 42 cycles" in {
+    Driver(() => new CounterAccelerator(42), "firrtl")(dut => new CounterAcceleratorTester(dut)) should be (true)
   }
 
 }


### PR DESCRIPTION
This renames the `esptests.TimerAccelerator` as a `esp.examples.CounterAccelerator`. The original test remains the same.