### PR TITLE
Emit ESP Accelerator XML Configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,8 @@ val defaultVersions = Map(
 libraryDependencies ++= (Seq("chisel3","chisel-iotesters").map {
   dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })
 
+libraryDependencies += "com.thoughtworks.xstream" % "xstream" % "1.4.11.1"
+
 scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
 
 javacOptions ++= javacOptionsVersion(scalaVersion.value)

--- a/src/main/scala/esp/AcceleratorWrapper.scala
+++ b/src/main/scala/esp/AcceleratorWrapper.scala
@@ -63,7 +63,19 @@ trait AcceleratorWrapperIO { this: RawModule =>
   val dma_write_chnl_data = IO(Output(UInt(32.W)))
 }
 
-class AcceleratorWrapper(gen: => Accelerator) extends RawModule with AcceleratorWrapperIO {
+/** Wraps a given [[Accelerator]] in a predicatable top-level interface. This is intended for direct integration with
+  * the ESP acclerator socket.
+  * @param gen the accelerator to wrap
+  * @param subName the top-level "name" of the accelerator
+  * @param parameters a string, typically consiting of stringified parameters, used to disambiguate this instance of the
+  * accelerator from anoter
+  * @todo Make subName and parameters automatically inferred based on gen. This requires some merged support added to
+  * Chisel.
+  */
+class AcceleratorWrapper(gen: => Accelerator, subName: String, parameters: String) extends RawModule
+    with AcceleratorWrapperIO {
+
+  override lazy val desiredName = s"${subName}_${parameters}_Wrapper"
   val acc = withClockAndReset(clk, rst)(Module(gen))
 
   acc.io.conf.bits.length       := conf_info_len

--- a/src/main/scala/esp/Annotations.scala
+++ b/src/main/scala/esp/Annotations.scala
@@ -1,0 +1,73 @@
+// Copyright 2018 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esp
+
+import firrtl.annotations.{ModuleName, SingleTargetAnnotation}
+
+import com.thoughtworks.xstream.XStream
+import com.thoughtworks.xstream.io.{HierarchicalStreamReader, HierarchicalStreamWriter}
+import com.thoughtworks.xstream.io.xml.{DomDriver, XmlFriendlyNameCoder}
+import com.thoughtworks.xstream.converters.{Converter, MarshallingContext, UnmarshallingContext}
+
+class AcceleratorParameterConverter extends Converter {
+
+  override def marshal(source: scala.Any, writer: HierarchicalStreamWriter, context: MarshallingContext): Unit = {
+    val c = source.asInstanceOf[AcceleratorParameter]
+    writer.addAttribute("name", c.name)
+    if (c.description.isDefined) { writer.addAttribute("desc", c.description.get) }
+    if (c.value.isDefined) { writer.addAttribute("value", c.value.get.toString) }
+  }
+
+  override def unmarshal(reader: HierarchicalStreamReader, context: UnmarshallingContext): AnyRef = {
+    ??? /* This is currently unimplemented */
+  }
+
+  override def canConvert(c: Class[_]): Boolean = c.isAssignableFrom(classOf[AcceleratorParameter])
+
+}
+
+/** Encodes ESP configuration and can serialize to SLD-compatible XML.
+  * @param target the module this configuration applies to
+  * @param config the ESP accelerator configuration
+  * @param dir either a (left) absolute path or (right) a path relative to a [[TargetDirAnnotation]]
+  */
+case class EspConfigAnnotation(target: ModuleName, config: AcceleratorConfig, dir: Either[String, String] = Right(".."))
+    extends SingleTargetAnnotation[ModuleName] {
+
+  def duplicate(targetx: ModuleName): EspConfigAnnotation = this.copy(target=targetx)
+
+  def toXML: String = {
+    val xs = new XStream(new DomDriver("UTF-8", new XmlFriendlyNameCoder("_", "_")))
+
+    xs.registerConverter(new AcceleratorParameterConverter)
+    // xs.aliasSystemAttribute(null, "class")
+    xs.alias("sld", this.getClass)
+    xs.aliasField("accelerator", this.getClass, "config")
+    xs.useAttributeFor(config.getClass, "name")
+    xs.useAttributeFor(config.getClass, "description")
+    xs.aliasField("desc", config.getClass, "description")
+    xs.useAttributeFor(config.getClass, "memoryFootprintMiB")
+    xs.aliasField("data_size", config.getClass, "memoryFootprintMiB")
+    xs.useAttributeFor(config.getClass, "deviceId")
+    xs.aliasField("device_id", config.getClass, "deviceId")
+    xs.addImplicitArray(config.getClass, "param")
+    xs.alias("param", classOf[AcceleratorParameter])
+    xs.useAttributeFor(classOf[AcceleratorParameter], "name")
+    xs.aliasField("desc", classOf[AcceleratorParameter], "description")
+    xs.useAttributeFor(classOf[AcceleratorParameter], "description")
+    xs.omitField(classOf[AcceleratorParameter], "readOnly")
+    xs.toXML(this)
+  }
+}

--- a/src/main/scala/esp/Generator.scala
+++ b/src/main/scala/esp/Generator.scala
@@ -21,12 +21,13 @@ import esp.examples.CounterAccelerator
 object Generator {
 
   def main(args: Array[String]): Unit = {
-    val examples: Seq[(String, () => Accelerator)] = Seq(
-      ("CounterAccelerator42", () => new CounterAccelerator(42)) )
+    val examples: Seq[(String, String, () => Accelerator)] = Seq(
+      ("CounterAccelerator", 42.toString, () => new CounterAccelerator(42)) )
 
-    examples.map { case (name, gen) =>
-      val argsx = args ++ Array("--target-dir", s"build/$name")
-      Driver.execute(argsx, () => new AcceleratorWrapper(gen())) }
+    examples.map { case (name, parameters, gen) =>
+      val argsx = args ++ Array("--target-dir", s"build/$name/${name}_${parameters}_Wrapper",
+                                "--custom-transforms", "esp.transforms.EmitXML")
+      Driver.execute(argsx, () => new AcceleratorWrapper(gen(), name, "42")) }
   }
 
 }

--- a/src/main/scala/esp/examples/CounterAccelerator.scala
+++ b/src/main/scala/esp/examples/CounterAccelerator.scala
@@ -17,12 +17,33 @@ package esp.examples
 import chisel3._
 import chisel3.util.Counter
 
-import esp.Accelerator
+import esp.{Accelerator, AcceleratorConfig, AcceleratorParameter}
+
+import sys.process._
 
 /** An ESP accelerator that is done a parameterized number of clock ticks in the future
   * @param ticks the number of clock ticks until done
   */
 class CounterAccelerator(val ticks: Int) extends Accelerator {
+
+  override val config = AcceleratorConfig(
+    name = this.name,
+    description = s"Simple accelerator that reports being done $ticks cycles after being enabled",
+    memoryFootprintMiB = 0,
+    deviceId = 0xC,
+    param = Array(
+      AcceleratorParameter(
+        name = "gitHash",
+        description = Some("Git short SHA hash of the repo used to generate this accelerator"),
+        value = Some(Integer.parseInt(("git log -n1 --format=%h" !!).filter(_ >= ' '), 16))
+      ),
+      AcceleratorParameter(
+        name = "ticks",
+        description = Some("read only tick count"),
+        value = Some(ticks))
+    )
+  )
+
   val enabled = RegInit(false.B)
 
   val (_, fire) = Counter(enabled, ticks)

--- a/src/main/scala/esp/transforms/EmitXML.scala
+++ b/src/main/scala/esp/transforms/EmitXML.scala
@@ -1,0 +1,42 @@
+// Copyright 2018 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esp.transforms
+
+import esp.EspConfigAnnotation
+
+import java.io.{File, PrintWriter}
+
+import firrtl.{CircuitForm, CircuitState, FIRRTLException, HighForm, TargetDirAnnotation, Transform}
+
+class EmitXML extends Transform {
+  def inputForm: CircuitForm = HighForm
+  def outputForm: CircuitForm = HighForm
+
+  def execute(state: CircuitState): CircuitState = {
+    lazy val targetDir: String = state.annotations.collectFirst{ case TargetDirAnnotation(d) => d }.getOrElse{
+      throw new FIRRTLException("EmitXML expected to see a TargetDirAnnotation, but none found?") }
+    state.annotations.collect{ case a @ EspConfigAnnotation(_, c, d) =>
+      val dir = d match {
+        case Left(absolute) => new File(absolute, s"${c.name}.xml")
+        case Right(relative) => new File(targetDir, new File(relative, s"${c.name}.xml").toString)
+      }
+      val w = new PrintWriter(dir)
+      w.write(a.toXML)
+      w.close()
+    }
+
+    state
+  }
+}


### PR DESCRIPTION
This adds support for emission of an ESP Accelerator configuration in XML
via a trivial FIRRTL Transform, EmitXML. The Accelerator class is now
abstract in definition of a config method that encapsulates all necessary
information about the accelerator that the ESP framework expects.

Fixes #8