### PR TITLE
Specifcation/Implementation Refactor, fix naming

### DIFF
--- a/src/main/scala/esp/Annotations.scala
+++ b/src/main/scala/esp/Annotations.scala
@@ -1,4 +1,4 @@
-// Copyright 2018 IBM
+// Copyright 2018-2019 IBM
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ import com.thoughtworks.xstream.io.{HierarchicalStreamReader, HierarchicalStream
 import com.thoughtworks.xstream.io.xml.{DomDriver, XmlFriendlyNameCoder}
 import com.thoughtworks.xstream.converters.{Converter, MarshallingContext, UnmarshallingContext}
 
-class AcceleratorParameterConverter extends Converter {
+class ParameterConverter extends Converter {
 
   override def marshal(source: scala.Any, writer: HierarchicalStreamWriter, context: MarshallingContext): Unit = {
-    val c = source.asInstanceOf[AcceleratorParameter]
+    val c = source.asInstanceOf[Parameter]
     writer.addAttribute("name", c.name)
     if (c.description.isDefined) { writer.addAttribute("desc", c.description.get) }
     if (c.value.isDefined) { writer.addAttribute("value", c.value.get.toString) }
@@ -34,7 +34,7 @@ class AcceleratorParameterConverter extends Converter {
     ??? /* This is currently unimplemented */
   }
 
-  override def canConvert(c: Class[_]): Boolean = c.isAssignableFrom(classOf[AcceleratorParameter])
+  override def canConvert(c: Class[_]): Boolean = c.isAssignableFrom(classOf[Parameter])
 
 }
 
@@ -43,7 +43,7 @@ class AcceleratorParameterConverter extends Converter {
   * @param config the ESP accelerator configuration
   * @param dir either a (left) absolute path or (right) a path relative to a [[TargetDirAnnotation]]
   */
-case class EspConfigAnnotation(target: ModuleName, config: AcceleratorConfig, dir: Either[String, String] = Right(".."))
+case class EspConfigAnnotation(target: ModuleName, config: Config, dir: Either[String, String] = Right(".."))
     extends SingleTargetAnnotation[ModuleName] {
 
   def duplicate(targetx: ModuleName): EspConfigAnnotation = this.copy(target=targetx)
@@ -51,7 +51,7 @@ case class EspConfigAnnotation(target: ModuleName, config: AcceleratorConfig, di
   def toXML: String = {
     val xs = new XStream(new DomDriver("UTF-8", new XmlFriendlyNameCoder("_", "_")))
 
-    xs.registerConverter(new AcceleratorParameterConverter)
+    xs.registerConverter(new ParameterConverter)
     // xs.aliasSystemAttribute(null, "class")
     xs.alias("sld", this.getClass)
     xs.aliasField("accelerator", this.getClass, "config")
@@ -63,11 +63,11 @@ case class EspConfigAnnotation(target: ModuleName, config: AcceleratorConfig, di
     xs.useAttributeFor(config.getClass, "deviceId")
     xs.aliasField("device_id", config.getClass, "deviceId")
     xs.addImplicitArray(config.getClass, "param")
-    xs.alias("param", classOf[AcceleratorParameter])
-    xs.useAttributeFor(classOf[AcceleratorParameter], "name")
-    xs.aliasField("desc", classOf[AcceleratorParameter], "description")
-    xs.useAttributeFor(classOf[AcceleratorParameter], "description")
-    xs.omitField(classOf[AcceleratorParameter], "readOnly")
+    xs.alias("param", classOf[Parameter])
+    xs.useAttributeFor(classOf[Parameter], "name")
+    xs.aliasField("desc", classOf[Parameter], "description")
+    xs.useAttributeFor(classOf[Parameter], "description")
+    xs.omitField(classOf[Parameter], "readOnly")
     xs.toXML(this)
   }
 }

--- a/src/main/scala/esp/Generator.scala
+++ b/src/main/scala/esp/Generator.scala
@@ -1,4 +1,4 @@
-// Copyright 2018 IBM
+// Copyright 2018-2019 IBM
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,13 +21,16 @@ import esp.examples.CounterAccelerator
 object Generator {
 
   def main(args: Array[String]): Unit = {
-    val examples: Seq[(String, String, () => Accelerator)] = Seq(
-      ("CounterAccelerator", 42.toString, () => new CounterAccelerator(42)) )
+    val examples: Seq[(String, String, () => AcceleratorWrapper)] =
+      Seq( ("CounterAccelerator", "Default", (a: Int) => new CounterAccelerator(a)) )
+        .flatMap( a => Seq(32, 64, 128).map(b => (a._1, s"${a._2}_dma$b", () => new AcceleratorWrapper(b, a._3))) )
 
-    examples.map { case (name, parameters, gen) =>
-      val argsx = args ++ Array("--target-dir", s"build/$name/${name}_${parameters}_Wrapper",
+    examples.map { case (name, impl, gen) =>
+      val argsx = args ++ Array("--target-dir", s"build/$name/${name}_$impl",
                                 "--custom-transforms", "esp.transforms.EmitXML")
-      Driver.execute(argsx, () => new AcceleratorWrapper(gen(), name, "42")) }
+      Driver.execute(argsx, gen)
+    }
+
   }
 
 }

--- a/src/main/scala/esp/Specification.scala
+++ b/src/main/scala/esp/Specification.scala
@@ -1,0 +1,64 @@
+// Copyright 2018-2019 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package esp
+
+/** A parameter used to configure the [[Specification]].
+  * @param name the name of the parameter
+  * @param description an optional string describing what this parameter sets/controls
+  * @param value an optional read-only, default value for this parameter
+  * @param size the width of this parameter in bits (1--32)
+  */
+case class Parameter(
+  name: String,
+  description: Option[String] = None,
+  value: Option[Int] = None,
+  size: Int = 32) {
+
+  val readOnly = value.isDefined
+
+  require(size >= 0, s"AccleratorParamater '$name' must be greater than 0 bits in size!")
+  require(size <= 32, s"AccleratorParamater '$name' must be less than or equal to 32 bits in size!")
+
+  def espString: String = name + (if (value.isDefined) s"_${value.get}" else "")
+}
+
+/** Mandatory configuration information that defines an ESP accelerator [[Specification]].
+  * @param name the specification name
+  * @param description a string describing what this specification does
+  * @param memoryFootprintMiB the accelerator's memory footprint
+  * @param deviceId a unique device identifier
+  * @param param an optional array of parameters describing configuration registers
+  */
+case class Config(
+  name: String,
+  description: String,
+  memoryFootprintMiB: Int,
+  deviceId: Int,
+  param: Array[Parameter] = Array.empty) {
+
+  require(memoryFootprintMiB >= 0, s"AcceleratorConfig '$name' memory footprint must be greater than 0 MiB!")
+
+  def espString: String = (name +: param).mkString("_")
+
+}
+
+/** This defines ESP configuration information shared across a range of accelerator [[Implementation]]s. */
+trait Specification {
+
+  /** An ESP [[Config]] that provides information to the ESP framework necessary to insert an accelerator into an ESP
+    * SoC.
+    */
+  def config: Config
+
+}

--- a/src/main/scala/esp/examples/CounterAccelerator.scala
+++ b/src/main/scala/esp/examples/CounterAccelerator.scala
@@ -1,4 +1,4 @@
-// Copyright 2018 IBM
+// Copyright 2018-2019 IBM
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,38 +17,51 @@ package esp.examples
 import chisel3._
 import chisel3.util.Counter
 
-import esp.{Accelerator, AcceleratorConfig, AcceleratorParameter}
+import esp.{Config, Implementation, Parameter, Specification}
 
 import sys.process._
 
 /** An ESP accelerator that is done a parameterized number of clock ticks in the future
   * @param ticks the number of clock ticks until done
   */
-class CounterAccelerator(val ticks: Int) extends Accelerator {
+trait CounterSpecification extends Specification {
 
-  override val config = AcceleratorConfig(
-    name = this.name,
-    description = s"Simple accelerator that reports being done $ticks cycles after being enabled",
+  def ticks: Int
+
+  /* This defines the abstract member config that provides necessary information for the ESP framework to generate an XML
+   * accelerator configuration. At the Chisel level, this will be used to emit an [[esp.EspConfigAnnotation]] which will
+   * be converted to an XML description by a custom FIRRTL transform, [[esp.transforms.EmitXML]]. */
+  override lazy val config: Config = Config(
+    name = "CounterAccelerator",
+    description = s"Simple accelerator that reports being done a fixed number of cycles after being enabled",
     memoryFootprintMiB = 0,
     deviceId = 0xC,
     param = Array(
-      AcceleratorParameter(
+      Parameter(
         name = "gitHash",
         description = Some("Git short SHA hash of the repo used to generate this accelerator"),
         value = Some(Integer.parseInt(("git log -n1 --format=%h" !!).filter(_ >= ' '), 16))
       ),
-      AcceleratorParameter(
+      Parameter(
         name = "ticks",
         description = Some("read only tick count"),
         value = Some(ticks))
     )
   )
 
+}
+
+class CounterAccelerator(dmaWidth: Int) extends Implementation(dmaWidth) with CounterSpecification {
+
+  override val ticks: Int = 42
+  override val implementationName: String = "Default"
+
   val enabled = RegInit(false.B)
 
-  val (_, fire) = Counter(enabled, ticks)
+  val (_, fire) = Counter(enabled, 42)
   io.done := fire
 
   when (io.conf.valid) { enabled := true.B  }
   when (fire)          { enabled := false.B }
+
 }

--- a/src/test/scala/esptests/AcceleratorWrapperSpec.scala
+++ b/src/test/scala/esptests/AcceleratorWrapperSpec.scala
@@ -1,4 +1,4 @@
-// Copyright 2018 IBM
+// Copyright 2018-2019 IBM
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import firrtl.{ir => fir}
 import org.scalatest.{FlatSpec, Matchers}
 import scala.io.Source
 import scala.util.matching.Regex
-import esp.{Accelerator, AcceleratorConfig, AcceleratorWrapper}
+import esp.{AcceleratorWrapper, Config, Implementation, Specification}
 
 class AcceleratorWrapperSpec extends FlatSpec with Matchers {
 
@@ -46,13 +46,19 @@ class AcceleratorWrapperSpec extends FlatSpec with Matchers {
                          tpe=fir.UIntType(fir.IntWidth(math.abs(n2z(m.group("high")) - n2z(m.group("low")) + 1)))))
   }
 
-  class FooAccelerator extends Accelerator {
-    val config = AcceleratorConfig(
+  trait FooSpecification extends Specification {
+    override val config: Config = Config(
       name = "foo",
       description = "a dummy accelerator used for unit tests",
       memoryFootprintMiB = 0,
       deviceId = 0
     )
+  }
+
+  class BarImplementation(dmaWidth: Int) extends Implementation(dmaWidth: Int) with FooSpecification {
+
+    override val implementationName: String = "bar"
+
   }
 
   behavior of "AcceleratorWrapper"
@@ -62,10 +68,10 @@ class AcceleratorWrapperSpec extends FlatSpec with Matchers {
 
     info("Verilog generation okay")
     Driver.execute(Array("-X", "verilog", "--target-dir", targetDir),
-                   () => new AcceleratorWrapper(new FooAccelerator, "FooAccelerator", "None"))
+                   () => new AcceleratorWrapper(32, (a: Int) => new BarImplementation(a)))
 
     val expectedIO = collectVerilogIO(Source.fromFile("src/main/resources/esp_acc_iface.v").getLines.toSeq)
-    val generatedIO = collectVerilogIO(Source.fromFile(s"$targetDir/FooAccelerator_None_Wrapper.v").getLines.toSeq).toSet
+    val generatedIO = collectVerilogIO(Source.fromFile(s"$targetDir/foo_bar.v").getLines.toSeq).toSet
 
     for (g <- expectedIO) {
       info(s"Contains: ${g.serialize}")

--- a/src/test/scala/esptests/examples/CounterAcceleratorSpec.scala
+++ b/src/test/scala/esptests/examples/CounterAcceleratorSpec.scala
@@ -1,4 +1,4 @@
-// Copyright 2018 IBM
+// Copyright 2018-2019 IBM
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ package esptests
 
 import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 
-import esp.Accelerator
 import esp.examples.CounterAccelerator
 
 /** A test that the [[CounterAccelerator]] asserts it's done when it should
@@ -51,7 +50,7 @@ class AcceleratorSpec extends ChiselFlatSpec {
   behavior of "CounterAccelerator"
 
   it should "assert done after 42 cycles" in {
-    Driver(() => new CounterAccelerator(42), "firrtl")(dut => new CounterAcceleratorTester(dut)) should be (true)
+    Driver(() => new CounterAccelerator(32), "firrtl")(dut => new CounterAcceleratorTester(dut)) should be (true)
   }
 
 }


### PR DESCRIPTION
This refactors esp.Accelerator into esp.Specification and
esp.Implementation. A Specification defines what an accelerator looks
like while its Implementation describes one point in the design space
that meets a given Specification.

This refactor has the byproduct of providing the right structure that
produces the correct naming for accelerators that ESP wants.
Specifically, you should have an accelerator directory that looks like
the following:

```
  targetDir
  └── ${specification}
      ├── ${specification}_${implementation}_dma${dmaWidth}
      │   └── ${specification}_${implementation}_dma${dmaWidth}.v
      └── ${specification}.xml
```

By explicitly separating the Specification from the Implementation,
generating the correct output structure and naming can be done. This
commit uses the Specification/Implementation to fix output naming.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@ibm.com>