### PR TITLE
Accelerator Interface Has User-Defined Ports

### DIFF
--- a/src/main/scala/esp/Annotations.scala
+++ b/src/main/scala/esp/Annotations.scala
@@ -68,6 +68,9 @@ case class EspConfigAnnotation(target: ModuleName, config: Config, dir: Either[S
     xs.aliasField("desc", classOf[Parameter], "description")
     xs.useAttributeFor(classOf[Parameter], "description")
     xs.omitField(classOf[Parameter], "readOnly")
+    xs.omitField(config.getClass, "paramMap")
+    xs.omitField(this.getClass, "target")
+    xs.omitField(this.getClass, "dir")
     xs.toXML(this)
   }
 }

--- a/src/main/scala/esp/Generator.scala
+++ b/src/main/scala/esp/Generator.scala
@@ -16,14 +16,14 @@ package esp
 
 import chisel3.Driver
 
-import esp.examples._
+import esp.examples.CounterAccelerator
 
 object Generator {
 
   def main(args: Array[String]): Unit = {
-    val examples: Seq[(String, String, () => CounterAcceleratorWrapper)] =
+    val examples: Seq[(String, String, () => AcceleratorWrapper)] =
       Seq( ("CounterAccelerator", "Default", (a: Int) => new CounterAccelerator(a)) )
-        .flatMap( a => Seq(32, 64, 128).map(b => (a._1, s"${a._2}_dma$b", () => new CounterAcceleratorWrapper(b, a._3))) )
+        .flatMap( a => Seq(32, 64, 128).map(b => (a._1, s"${a._2}_dma$b", () => new AcceleratorWrapper(b, a._3))) )
 
     examples.map { case (name, impl, gen) =>
       val argsx = args ++ Array("--target-dir", s"build/$name/${name}_$impl",

--- a/src/main/scala/esp/Generator.scala
+++ b/src/main/scala/esp/Generator.scala
@@ -16,14 +16,14 @@ package esp
 
 import chisel3.Driver
 
-import esp.examples.CounterAccelerator
+import esp.examples._
 
 object Generator {
 
   def main(args: Array[String]): Unit = {
-    val examples: Seq[(String, String, () => AcceleratorWrapper)] =
+    val examples: Seq[(String, String, () => CounterAcceleratorWrapper)] =
       Seq( ("CounterAccelerator", "Default", (a: Int) => new CounterAccelerator(a)) )
-        .flatMap( a => Seq(32, 64, 128).map(b => (a._1, s"${a._2}_dma$b", () => new AcceleratorWrapper(b, a._3))) )
+        .flatMap( a => Seq(32, 64, 128).map(b => (a._1, s"${a._2}_dma$b", () => new CounterAcceleratorWrapper(b, a._3))) )
 
     examples.map { case (name, impl, gen) =>
       val argsx = args ++ Array("--target-dir", s"build/$name/${name}_$impl",

--- a/src/main/scala/esp/Implementation.scala
+++ b/src/main/scala/esp/Implementation.scala
@@ -20,6 +20,24 @@ import chisel3.util.{Decoupled, Valid}
 
 import firrtl.annotations.Annotation
 
+import scala.collection.immutable
+
+class ConfigIO private (espConfig: Config) extends Record {
+  val elements = immutable.ListMap(espConfig.param.collect{ case a if !a.readOnly => a.name -> UInt(a.size.W)}: _*)
+  override def cloneType: this.type = (new ConfigIO(espConfig)).asInstanceOf[this.type]
+  def apply(a: String): Data = elements(a)
+}
+
+object ConfigIO {
+
+  def apply(espConfig: Config): Option[ConfigIO] = {
+    val rwParameters = espConfig.param.collect{ case a if !a.readOnly => a.name -> UInt(a.size.W) }
+    if (rwParameters.isEmpty) { None                          }
+    else                      { Some(new ConfigIO(espConfig)) }
+  }
+
+}
+
 class DmaControl extends Bundle {
   val index = UInt(32.W)
   val length = UInt(32.W)
@@ -31,20 +49,24 @@ class DmaIO(width: Int) extends Bundle {
   val writeChannel = Decoupled(UInt(width.W))
 }
 
-class AcceleratorIO(val dmaWidth: Int) extends Bundle {
+class AcceleratorIO(val dmaWidth: Int, val espConfig: Config) extends Bundle {
   val enable = Input(Bool())
+  val config = ConfigIO(espConfig).map(Input(_))
   val dma = new DmaIO(dmaWidth)
   val done = Output(Bool())
   val debug = Output(UInt(32.W))
 }
 
+
 /** This contains the underlying hardware that implements an ESP accelerator [[Specification]]. A concrete subclass of
   * [[Implementation]] represents one point in the design space for all accelerators meeting the [[Specification]].
   * @param dmaWidth the width of the connection to the memory bus
   */
-abstract class Implementation(dmaWidth: Int) extends Module with Specification { self: Implementation =>
+abstract class Implementation(val dmaWidth: Int) extends Module with Specification { self: Implementation =>
 
-  /** This defines a name describing this implementation.  */
+  lazy val io = IO(new AcceleratorIO(dmaWidth, config))
+
+  /** This defines a name describing this implementation. */
   def implementationName: String
 
   chisel3.experimental.annotate(
@@ -53,21 +75,19 @@ abstract class Implementation(dmaWidth: Int) extends Module with Specification {
     }
   )
 
-  def InitCommonIo(io: AcceleratorIO) {
-    io.done := false.B
-    io.debug := 0.U
+  io.done := false.B
+  io.debug := 0.U
 
-    io.dma.readControl.valid := false.B
-    io.dma.readControl.bits.index := 0.U
-    io.dma.readControl.bits.length := 0.U
+  io.dma.readControl.valid := false.B
+  io.dma.readControl.bits.index := 0.U
+  io.dma.readControl.bits.length := 0.U
 
-    io.dma.writeControl.valid := false.B
-    io.dma.writeControl.bits.index := 0.U
-    io.dma.writeControl.bits.length := 0.U
+  io.dma.writeControl.valid := false.B
+  io.dma.writeControl.bits.index := 0.U
+  io.dma.writeControl.bits.length := 0.U
 
-    io.dma.readChannel.ready := 0.U
+  io.dma.readChannel.ready := 0.U
 
-    io.dma.writeChannel.valid := 0.U
-    io.dma.writeChannel.bits := 0.U
-  }
+  io.dma.writeChannel.valid := 0.U
+  io.dma.writeChannel.bits := 0.U
 }

--- a/src/main/scala/esp/Implementation.scala
+++ b/src/main/scala/esp/Implementation.scala
@@ -20,11 +20,6 @@ import chisel3.util.{Decoupled, Valid}
 
 import firrtl.annotations.Annotation
 
-class Configuration extends Bundle {
-  val length = UInt(32.W)
-  val batch = UInt(32.W)
-}
-
 class DmaControl extends Bundle {
   val index = UInt(32.W)
   val length = UInt(32.W)
@@ -37,7 +32,7 @@ class DmaIO(width: Int) extends Bundle {
 }
 
 class AcceleratorIO(val dmaWidth: Int) extends Bundle {
-  val conf = Input(Valid(new Configuration))
+  val enable = Input(Bool())
   val dma = new DmaIO(dmaWidth)
   val done = Output(Bool())
   val debug = Output(UInt(32.W))
@@ -49,8 +44,6 @@ class AcceleratorIO(val dmaWidth: Int) extends Bundle {
   */
 abstract class Implementation(dmaWidth: Int) extends Module with Specification { self: Implementation =>
 
-  final lazy val io = IO(new AcceleratorIO(dmaWidth))
-
   /** This defines a name describing this implementation.  */
   def implementationName: String
 
@@ -60,19 +53,21 @@ abstract class Implementation(dmaWidth: Int) extends Module with Specification {
     }
   )
 
-  io.done := false.B
-  io.debug := 0.U
+  def InitCommonIo(io: AcceleratorIO) {
+    io.done := false.B
+    io.debug := 0.U
 
-  io.dma.readControl.valid := false.B
-  io.dma.readControl.bits.index := 0.U
-  io.dma.readControl.bits.length := 0.U
+    io.dma.readControl.valid := false.B
+    io.dma.readControl.bits.index := 0.U
+    io.dma.readControl.bits.length := 0.U
 
-  io.dma.writeControl.valid := false.B
-  io.dma.writeControl.bits.index := 0.U
-  io.dma.writeControl.bits.length := 0.U
+    io.dma.writeControl.valid := false.B
+    io.dma.writeControl.bits.index := 0.U
+    io.dma.writeControl.bits.length := 0.U
 
-  io.dma.readChannel.ready := 0.U
+    io.dma.readChannel.ready := 0.U
 
-  io.dma.writeChannel.valid := 0.U
-  io.dma.writeChannel.bits := 0.U
+    io.dma.writeChannel.valid := 0.U
+    io.dma.writeChannel.bits := 0.U
+  }
 }

--- a/src/main/scala/esp/Specification.scala
+++ b/src/main/scala/esp/Specification.scala
@@ -51,6 +51,13 @@ case class Config(
 
   def espString: String = (name +: param).mkString("_")
 
+  val paramMap: Map[String, Parameter] = param
+    .groupBy(_.name)
+    .map{ case (k, v) =>
+      require(v.size == 1, s"AcceleratorConfig '$name' has non-uniquely named parameter '$k'")
+      k -> v.head
+    }
+
 }
 
 /** This defines ESP configuration information shared across a range of accelerator [[Implementation]]s. */

--- a/src/main/scala/esp/examples/CounterAccelerator.scala
+++ b/src/main/scala/esp/examples/CounterAccelerator.scala
@@ -33,7 +33,7 @@ trait CounterSpecification extends Specification {
    * be converted to an XML description by a custom FIRRTL transform, [[esp.transforms.EmitXML]]. */
   override lazy val config: Config = Config(
     name = "CounterAccelerator",
-    description = s"Simple accelerator that reports being done a fixed number of cycles after being enabled",
+    description = s"Fixed-count timer",
     memoryFootprintMiB = 0,
     deviceId = 0xC,
     param = Array(

--- a/src/main/scala/esp/examples/CounterAccelerator.scala
+++ b/src/main/scala/esp/examples/CounterAccelerator.scala
@@ -54,7 +54,7 @@ trait CounterSpecification extends Specification {
 class CounterAccelerator(dmaWidth: Int) extends Implementation(dmaWidth) with CounterSpecification {
 
   override val ticks: Int = 42
-  override val implementationName: String = "Default"
+  override val implementationName: String = "Default_dma" + dmaWidth
 
   val enabled = RegInit(false.B)
 

--- a/src/test/scala/esptests/AcceleratorWrapperSpec.scala
+++ b/src/test/scala/esptests/AcceleratorWrapperSpec.scala
@@ -19,7 +19,7 @@ import firrtl.{ir => fir}
 import org.scalatest.{FlatSpec, Matchers}
 import scala.io.Source
 import scala.util.matching.Regex
-import esp.{AcceleratorWrapper, Config, Implementation, Specification}
+import esp.{AcceleratorWrapper, Config, Implementation, Parameter, Specification}
 
 class AcceleratorWrapperSpec extends FlatSpec with Matchers {
 
@@ -47,11 +47,15 @@ class AcceleratorWrapperSpec extends FlatSpec with Matchers {
   }
 
   trait FooSpecification extends Specification {
-    override val config: Config = Config(
+    override lazy val config: Config = Config(
       name = "foo",
       description = "a dummy accelerator used for unit tests",
       memoryFootprintMiB = 0,
-      deviceId = 0
+      deviceId = 0,
+      param = Array(
+        Parameter("len"),
+        Parameter("batch")
+      )
     )
   }
 


### PR DESCRIPTION
An ESP accelerator can have user-defined input ports. These ports corresponds to writable registers that are exposed to software for configuration. The naming convention is 'conf_info_<register-name>' and each port is 32-bits wide.

The CounterAccelerator example has been edited to accept as input the number of ticks to count before asserting the done signal.