### PR TITLE
FFT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ofdm"]
+	path = ofdm
+	url = https://github.com/seldridge/ofdm

--- a/build.sbt
+++ b/build.sbt
@@ -24,30 +24,30 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
   }
 }
 
-name := "esp-chisel-accelerators"
+lazy val ofdm = (project in file("ofdm"))
 
-version := "1.0.0"
+// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
+val defaultVersions = Map(
+  "chisel-iotesters" -> "1.3.+",
+  "chisel-testers2" -> "0.1.+",
+  "dsptools" -> "1.2.+"
+  )
 
-scalaVersion := "2.12.8"
-
-crossScalaVersions := Seq("2.11.12", "2.12.8")
+lazy val espChisel = (project in file("."))
+  .settings(
+    name := "esp-chisel-accelerators",
+    version := "1.0.0",
+    scalaVersion := "2.12.10",
+    crossScalaVersions := Seq("2.11.12", "2.12.10"),
+    libraryDependencies ++= Seq("chisel-iotesters", "chisel-testers2", "dsptools")
+      .map { dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) },
+    libraryDependencies += "com.thoughtworks.xstream" % "xstream" % "1.4.11.1",
+    scalacOptions ++= scalacOptionsVersion(scalaVersion.value) ++
+      Seq("-unchecked", "-deprecation", "-Ywarn-unused-import"),
+    javacOptions ++= javacOptionsVersion(scalaVersion.value))
+  .dependsOn(ofdm)
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")
 )
-
-// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
-val defaultVersions = Map(
-  "chisel-iotesters" -> "1.3.+",
-  "chisel-testers2" -> "0.1.+"
-  )
-
-libraryDependencies ++= (Seq("chisel-iotesters", "chisel-testers2").map {
-  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })
-
-libraryDependencies += "com.thoughtworks.xstream" % "xstream" % "1.4.11.1"
-
-scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
-
-javacOptions ++= javacOptionsVersion(scalaVersion.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.1
+sbt.version = 1.3.2

--- a/src/main/scala/esp/Generator.scala
+++ b/src/main/scala/esp/Generator.scala
@@ -16,18 +16,20 @@ package esp
 
 import chisel3.Driver
 
-import esp.examples.CounterAccelerator
+import esp.examples.{CounterAccelerator, DefaultFFTAccelerator}
 
 object Generator {
 
   def main(args: Array[String]): Unit = {
     val examples: Seq[(String, String, () => AcceleratorWrapper)] =
-      Seq( ("CounterAccelerator", "Default", (a: Int) => new CounterAccelerator(a)) )
-        .flatMap( a => Seq(32, 64, 128).map(b => (a._1, s"${a._2}_dma$b", () => new AcceleratorWrapper(b, a._3))) )
+      Seq( ("CounterAccelerator", "Default", (a: Int) => new CounterAccelerator(a)),
+           ("FFTAccelerator", "Default", (a: Int) => new DefaultFFTAccelerator(a)) )
+        .flatMap( a => Seq(32).map(b => (a._1, s"${a._2}_dma$b", () => new AcceleratorWrapper(b, a._3))) )
 
     examples.map { case (name, impl, gen) =>
       val argsx = args ++ Array("--target-dir", s"build/$name/${name}_$impl",
-                                "--custom-transforms", "esp.transforms.EmitXML")
+                                "--custom-transforms", "esp.transforms.EmitXML",
+                                "--log-level", "info")
       Driver.execute(argsx, gen)
     }
 

--- a/src/main/scala/esp/examples/FFTAccelerator.scala
+++ b/src/main/scala/esp/examples/FFTAccelerator.scala
@@ -1,0 +1,223 @@
+// Copyright 2018-2019 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esp.examples
+
+import chisel3._
+import chisel3.experimental.{ChiselEnum, FixedPoint}
+import chisel3.util.{Queue, Valid}
+
+import dsptools.numbers._
+
+import esp.{Config, Implementation, Parameter, Specification}
+
+import java.io.File
+
+import ofdm.fft.{DISOIO, FFT, FFTParams, PacketSerializer, PacketSerDesParams}
+
+import sys.process.Process
+
+/* 64-bit, 40 binary point */
+
+trait FFTSpecification extends Specification {
+
+  val params: FFTParams[_]
+
+  private def gitHash(dir: Option[File] = None): Int = {
+    val cmd = Seq("git", "log", "-n1", "--format=%h")
+
+    val hash = dir match {
+      case Some(file) => Process(cmd, file).!!
+      case None       => Process(cmd).!!
+    }
+
+    java.lang.Integer.parseInt(hash.filter(_ >= ' '), 16)
+  }
+
+  override lazy val config: Config = Config(
+    name = "FFTAccelerator",
+    description = s"${params.numPoints}-point FFT",
+    memoryFootprintMiB = 0,
+    deviceId = 0xD,
+    param = Array(
+      Parameter(
+        name = "gitHash",
+        description = Some("Git short SHA hash of the repo used to generate this accelerator"),
+        value = Some(gitHash())
+      ),
+      Parameter(
+        name = "ofdmGitHash",
+        description = Some("Git short SHA hash of the grebe/ofdm repo used to generate this accelerator"),
+        value = Some(gitHash(Some(new File("ofdm"))))
+      ),
+      Parameter(
+        name = "startAddr",
+        description = Some("The memory address to start the FFT")
+      ),
+      Parameter(
+        name = "count",
+        description = Some("The number of 1D FFTs to do")
+      ),
+      Parameter(
+        name = "stride",
+        description = Some("The stride between each FFT")
+      )
+    )
+  )
+
+}
+
+object FFTAccelerator {
+
+  /** FFTAccelerator states for internal state machines */
+  object S extends ChiselEnum {
+    val Idle, DMALoad, DMAStore, Done = Value
+  }
+
+  /** FFTAccelerator error codes */
+  object Errors extends ChiselEnum {
+    val None = Value(0.U)
+    val InvalidWidth, Unimplemented = Value
+  }
+
+}
+
+/** An ESP accelerator that performs an N-point Fast Fourier Transform (FFT)
+  * @param dmaWidth the width of the ESP DMA bus
+  * @param params parameters describing the FFT
+  */
+class FFTAccelerator[A <: Data : Real : BinaryRepresentation](dmaWidth: Int, val params: FFTParams[A])
+    extends Implementation(dmaWidth) with FFTSpecification {
+
+  require(params.protoIQ.real.getWidth <= 32, "This FFT has bugs for bit widths > 32 bits!")
+
+  import FFTAccelerator._
+
+  private def unimplemented(): Unit = {
+    state := S.Done
+    debug := Errors.Unimplemented
+  }
+
+  override val implementationName: String = "Default_fft" + dmaWidth
+
+  /** The underlying FFT hardware */
+  val fft = Module(
+    new MultiIOModule {
+      val underlyingFFT = Module(new FFT(params))
+      val desser = Module(new PacketSerializer(PacketSerDesParams(params.protoIQ, params.numPoints)))
+      val in = IO(chiselTypeOf(underlyingFFT.io.in))
+      underlyingFFT.io.in <> in
+      desser.io.in <> underlyingFFT.io.out
+      val out = IO(chiselTypeOf(desser.io.out))
+      out <> desser.io.out
+    }
+  )
+  dontTouch(fft.in)
+  dontTouch(fft.out)
+
+  /** Indicates that this unit is busy computing a computation */
+  val state = RegInit(S.Idle)
+  val addr = Reg(chiselTypeOf(io.config.get("startAddr")).asUInt)
+  val count = Reg(chiselTypeOf(io.config.get("count")).asUInt)
+  val stride = Reg(chiselTypeOf(io.config.get("stride")).asUInt)
+  val debug = RegInit(Errors.None)
+
+  io.debug := debug.asUInt
+  io.done := true.B
+
+  fft.in.bits.real := DontCare
+  fft.in.bits.imag := DontCare
+  fft.in.valid := false.B
+
+  fft.out.ready := false.B
+
+  val dmaRead, dmaWrite = Reg(Valid(UInt(32.W)))
+
+  when (io.enable && state === S.Idle) {
+    addr := io.config.get("startAddr")
+    count := io.config.get("count")
+    stride := io.config.get("stride")
+
+    when (io.config.get("stride").asUInt =/= params.numPoints.U) {
+      state := S.Done
+      debug := Errors.InvalidWidth
+    }.elsewhen(io.config.get("count").asUInt =/= 1.U) {
+      unimplemented()
+    }.otherwise {
+      state := S.DMALoad
+      Seq(dmaRead, dmaWrite).foreach { a =>
+        a.valid := false.B
+        a.bits := 0.U
+      }
+    }
+  }
+
+  /* @todo cleanup this jank */
+  val real_d = Reg(params.protoIQ.real)
+  val readQueue = Module(new Queue(params.protoIQ, entries=2))
+  io.dma.readChannel.ready := readQueue.io.enq.ready
+  readQueue.io.enq.valid := io.dma.readChannel.valid && dmaRead.bits(0)
+  readQueue.io.enq.bits := DspComplex.wire(real_d, io.dma.readChannel.bits.asTypeOf(params.protoIQ.imag))
+  fft.in <> readQueue.io.deq
+
+  when (state === S.DMALoad) {
+    io.dma.readControl.valid := ~dmaRead.valid
+    io.dma.readControl.bits.index := addr
+    io.dma.readControl.bits.length := stride * count
+
+    when (io.dma.readControl.fire) {
+      dmaRead.valid := true.B
+    }
+
+    when (io.dma.readChannel.fire) {
+      dmaRead.bits := dmaRead.bits + 1.U
+      when (~dmaRead.bits(0)) {
+        real_d := io.dma.readChannel.bits.asTypeOf(real_d)
+      }
+      when (dmaRead.bits === stride * count * 2 - 1) {
+        state := S.DMAStore
+      }
+    }
+  }
+
+  io.dma.writeChannel.valid := dmaWrite.valid && fft.out.valid
+  fft.out.ready := dmaWrite.valid && dmaWrite.bits(0) && io.dma.writeChannel.ready
+  io.dma.writeChannel.bits := Mux(dmaWrite.bits(0), fft.out.bits.imag.asUInt, fft.out.bits.real.asUInt)
+
+  when (state === S.DMAStore) {
+    io.dma.writeControl.valid := ~dmaWrite.valid
+    io.dma.writeControl.bits.index := addr
+    io.dma.writeControl.bits.length := stride * count
+
+    when (io.dma.writeControl.fire) {
+      dmaWrite.valid := true.B
+    }
+
+    when (io.dma.writeChannel.fire) {
+      dmaWrite.bits := dmaWrite.bits + 1.U
+    }
+    when (dmaWrite.bits === stride * count * 2 - 1) {
+      state := S.Done
+    }
+  }
+
+  when (state === S.Done) {
+    state := S.Idle
+    debug := Errors.None
+  }
+
+}
+
+/** A 32-point 64.40 fixed point FFT accelerator */
+class DefaultFFTAccelerator(dmaWidth: Int) extends FFTAccelerator(dmaWidth, FFTParams.fixed(32, 20, 32, 32))

--- a/src/test/scala/esptests/examples/FFTAcceleratorSpec.scala
+++ b/src/test/scala/esptests/examples/FFTAcceleratorSpec.scala
@@ -1,0 +1,206 @@
+// Copyright 2018-2019 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esptests.examples
+
+import breeze.linalg.{DenseVector, randomDouble}
+import breeze.signal.fourierTr
+import breeze.math.Complex
+
+import chisel3._
+import chisel3.experimental.BundleLiterals._
+import chisel3.experimental.FixedPoint
+import chisel3.internal.firrtl.KnownBinaryPoint
+import chisel3.stage.{ChiselStage, ChiselGeneratorAnnotation}
+import chisel3.tester._
+import chisel3.tester.experimental.TestOptionBuilder._
+import chisel3.tester.internal.WriteVcdAnnotation
+
+import dsptools.numbers.DspComplex
+
+import esp.{DmaControl, DmaSize}
+import esp.examples.FFTAccelerator
+
+import firrtl.options.OptionsException
+
+import ofdm.fft.FFTParams
+
+import org.scalatest._
+
+import org.scalactic.Equality
+import org.scalactic.TripleEquals._
+import org.scalactic.Tolerance._
+
+class FFTAcceleratorSpec extends FlatSpec with ChiselScalatestTester with Matchers {
+
+  private implicit class FFTAcceleratorHelpers(dut: FFTAccelerator[_]) {
+    def doReset() = {
+      dut.reset.poke(true.B)
+      dut.io.enable.poke(false.B)
+      dut.io.dma.readControl.ready.poke(false.B)
+      dut.io.dma.writeControl.ready.poke(false.B)
+      dut.io.dma.readChannel.valid.poke(false.B)
+      dut.io.dma.writeChannel.ready.poke(false.B)
+      dut.clock.step(1)
+      dut.reset.poke(false.B)
+    }
+  }
+
+  private implicit class BigIntHelpers(a: BigInt) {
+    /** Convert from a BigInt to two's complement BigInt */
+    def toTwosComplement(width: Int, binaryPoint: BigInt) = a match {
+      case _ if a < 0 => a + BigInt(2).pow(width)
+      case _          => a
+    }
+
+    /** Convert from a BigInt in two's complement to a signed BigInt */
+    def fromTwosComplement(width: Int, binaryPoint: BigInt) = a match {
+      case _ if a >= BigInt(2).pow(width - 1) => a - BigInt(2).pow(width)
+      case _                                  => a
+    }
+  }
+
+  private implicit class FixedPointHelpers(a: FixedPoint) {
+    def toDouble = a.binaryPoint match {
+      case KnownBinaryPoint(value) => a.litValue.toDouble / math.pow(2, value)
+    }
+  }
+
+  private class ToleranceFixture(t: Double) {
+    implicit val theTolerance = new Equality[Double] {
+      def areEqual(a: Double, b: Any): Boolean = b match {
+        case bb: Double =>a === bb +- t
+        case _          => false
+      }
+    }
+  }
+
+  behavior of "FFTAccelerator"
+
+  it should "fail to elaborate for non-power-of-2 numbers of points" in {
+    /* @todo: It would be better to verify that this was more than just an OptionsException */
+    assertThrows[OptionsException] {
+      (new ChiselStage)
+        .execute(Array.empty, Seq(ChiselGeneratorAnnotation(() => new FFTAccelerator(32, FFTParams.fixed(8, 0, 8, 3)))))
+    }
+  }
+
+  it should "error for an FFT with stride not equal to its points size" in {
+    val numPoints = 4
+
+    info("errors for stride < points size")
+    test(new FFTAccelerator(32, FFTParams.fixed(32, 16, 32, numPoints))){ dut =>
+      dut.doReset()
+      dut.io.config.get("stride").poke((numPoints - 1).U)
+      dut.io.enable.poke(true.B)
+
+      dut.clock.step(1)
+      dut.io.done.expect(true.B)
+      dut.io.debug.expect(1.U) // @todo: Change this to check the enum vlaue
+    }
+
+    info("errors for stride > points size")
+    test(new FFTAccelerator(32, FFTParams.fixed(32, 16, 32, numPoints))){ dut =>
+      dut.doReset()
+      dut.io.config.get("stride").poke((numPoints + 1).U)
+      dut.io.enable.poke(true.B)
+
+      dut.clock.step(1)
+      dut.io.done.expect(true.B)
+      dut.io.debug.expect(1.U) // @todo: Change this to check the enum vlaue
+    }
+  }
+
+  it should "fail to elaborate for bit widths > 32" in {
+    assertThrows[OptionsException] {
+      (new ChiselStage)
+        .execute(Array.empty, Seq(ChiselGeneratorAnnotation(() => new FFTAccelerator(32, FFTParams.fixed(33, 16, 32, 8)))))
+    }
+  }
+
+  def testRandom(numPoints: Int, width: Int, binaryPoint: Int, tolerance: Double): Unit = {
+    val description = s"do a 1-D $numPoints-point $width.$binaryPoint fixed point FFT within $tolerance of double"
+    it should description in new ToleranceFixture(tolerance) {
+      val input       = DenseVector.fill(numPoints) { Complex(randomDouble() * 2 - 1, 0) }
+      val output      = fourierTr(input).toScalaVector
+
+      test(new FFTAccelerator(32, FFTParams.fixed(width, binaryPoint, width, numPoints)))
+        .withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+          dut.doReset()
+
+          dut.io.dma.readControl.initSink().setSinkClock(dut.clock)
+          dut.io.dma.readChannel.initSource().setSourceClock(dut.clock)
+          dut.io.dma.writeControl.initSink().setSinkClock(dut.clock)
+          dut.io.dma.writeChannel.initSink().setSinkClock(dut.clock)
+
+          dut.io.config.get("startAddr").poke(0.U)
+          dut.io.config.get("count").poke(1.U)
+          dut.io.config.get("stride").poke(numPoints.U)
+          dut.io.enable.poke(true.B)
+          dut.clock.step(1)
+
+          dut.io.enable.poke(false.B)
+
+          dut.io.dma.readControl.expectDequeue((new DmaControl).Lit(_.index -> 0.U, _.length -> numPoints.U, _.size -> DmaSize.word))
+
+          {
+            val inputx = input
+              .toArray
+              .flatMap(a => Seq(a.real, a.imag))
+              .map(FixedPoint.toBigInt(_, binaryPoint))
+              .map(_.toTwosComplement(width, binaryPoint))
+              .map(_.U)
+            dut.io.dma.readChannel.enqueueSeq(inputx)
+          }
+
+          dut.io.dma.writeControl.expectDequeue((new DmaControl).Lit(_.index -> 0.U, _.length -> numPoints.U, _.size -> DmaSize.word))
+
+          {
+            val outputx = output
+              .toArray
+              .flatMap(a => Seq(a.real, a.imag))
+              .map(FixedPoint.fromDouble(_, width.W, binaryPoint.BP))
+            val fftOut = for (i <- 0 until numPoints * 2) yield {
+              dut.io.dma.writeChannel.ready.poke(true.B)
+              while (dut.io.dma.writeChannel.valid.peek().litToBoolean == false) {
+                dut.clock.step(1)
+              }
+              dut.io.dma.writeChannel.valid.expect(true.B)
+              val tmp = FixedPoint
+                .fromBigInt(dut.io.dma.writeChannel.bits.peek().litValue.fromTwosComplement(width, binaryPoint), width, binaryPoint)
+              dut.clock.step(1)
+              tmp
+            }
+            fftOut.zip(outputx).foreach{ case (a: FixedPoint, b: FixedPoint) =>
+              val Seq(ax, bx) = Seq(a, b).map(_.toDouble)
+              ax should === (bx)
+            }
+          }
+
+        }
+    }
+  }
+
+  Seq(
+    (2,   32, 20, 0.001),
+    (4,   32, 20, 0.001),
+    (8,   32, 20, 0.001),
+    (16,  32, 20, 0.001),
+    (32,  32, 20, 0.001),
+    (64,  32, 20, 0.001),
+    (128, 32, 20, 0.001)).foreach((testRandom _).tupled)
+
+  it should "perform a 2-D convolution" in (pending)
+
+}


### PR DESCRIPTION
Adds an example FFT accelerator from the `ofdm` package. This pulls in [`grebe/ofdm`](https://github.com/grebe/ofdm) as a submodule. 

This current FFT generator has the following limitations:

- Fixed point sizes > 32 bits appear to have some bug. This may be either in my testing or in the generator. An assertion is setup to check that you don't use data types larger than this restriction.
- Point sizes > 512 will seriously stress the Chisel/FIRRTL compiler and likely run you out of memory. This is not necessarily indicative of anything wrong with this generator or the compiler, just that the microarchitecture for computing an FFT in this generator likely needs to change for large point sizes. This warrants further investigations.