### PR TITLE
Bump to Chisel 3.2.+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,11 +39,10 @@ resolvers ++= Seq(
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.1.+",
-  "chisel-iotesters" -> "1.2.+"
+  "chisel-iotesters" -> "1.3.+"
   )
 
-libraryDependencies ++= (Seq("chisel3","chisel-iotesters").map {
+libraryDependencies ++= (Seq("chisel-iotesters").map {
   dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })
 
 libraryDependencies += "com.thoughtworks.xstream" % "xstream" % "1.4.11.1"

--- a/src/main/scala/esp/AcceleratorWrapper.scala
+++ b/src/main/scala/esp/AcceleratorWrapper.scala
@@ -15,7 +15,6 @@
 package esp
 
 import chisel3._
-import chisel3.experimental.{RawModule, withClockAndReset}
 
 trait AcceleratorWrapperIO { this: RawModule =>
   val dmaWidth: Int

--- a/src/main/scala/esp/examples/CounterAccelerator.scala
+++ b/src/main/scala/esp/examples/CounterAccelerator.scala
@@ -15,7 +15,6 @@
 package esp.examples
 
 import chisel3._
-import chisel3.experimental.{RawModule, withClockAndReset}
 
 import esp.{Config, AcceleratorWrapperIO, AcceleratorIO, Implementation, Parameter, Specification}
 


### PR DESCRIPTION
- Bumps to Chisel 3.2.+
- Switches to a single dependency on testers
- Updates to remove references to the flattened `experimental` package