### PR TITLE
Improve FFTAccelerator XML Metadata

### DIFF
--- a/src/main/scala/esp/examples/FFTAccelerator.scala
+++ b/src/main/scala/esp/examples/FFTAccelerator.scala
@@ -47,7 +47,9 @@ trait FFTSpecification extends Specification {
 
   override lazy val config: Config = Config(
     name = "FFTAccelerator",
-    description = s"${params.numPoints}-point FFT",
+    description = params.protoIQ.real match {
+      case a: FixedPoint => s"${params.numPoints}-point ${a.getWidth}.${a.binaryPoint.get} FFT"
+    },
     memoryFootprintMiB = 0,
     deviceId = 0xD,
     param = Array(
@@ -63,15 +65,15 @@ trait FFTSpecification extends Specification {
       ),
       Parameter(
         name = "startAddr",
-        description = Some("The memory address to start the FFT")
+        description = Some("The memory address to start the FFT (output written here)")
       ),
       Parameter(
         name = "count",
-        description = Some("The number of 1D FFTs to do")
+        description = Some("The number of 1D FFTs to do (only 1 supported)")
       ),
       Parameter(
         name = "stride",
-        description = Some("The stride between each FFT")
+        description = Some("The stride between each FFT (must be point size)")
       )
     )
   )


### PR DESCRIPTION
This adds information about the fixed point format, where the output
is written, and limitations of count/strider.

XML metadata now looks like:

```xml
<sld>
  <accelerator name="FFTAccelerator" desc="32-point 32.20 FFT" data_size="0" device_id="13">
    <param name="gitHash" desc="Git short SHA hash of the repo used to generate this accelerator" value="255527551"/>
    <param name="ofdmGitHash" desc="Git short SHA hash of the grebe/ofdm repo used to generate this accelerator" value="142815556"/>
    <param name="startAddr" desc="The memory address to start the FFT (output written here)"/>
    <param name="count" desc="The number of 1D FFTs to do (only 1 supported)"/>
    <param name="stride" desc="The stride between each FFT (must be point size)"/>
  </accelerator>
</sld>
```