### PR TITLE
Fix bug where FFTAccelerator always asserts done

### DIFF
--- a/src/main/scala/esp/examples/FFTAccelerator.scala
+++ b/src/main/scala/esp/examples/FFTAccelerator.scala
@@ -136,7 +136,7 @@ class FFTAccelerator[A <: Data : Real : BinaryRepresentation](dmaWidth: Int, val
   val debug = RegInit(Errors.None)
 
   io.debug := debug.asUInt
-  io.done := true.B
+  io.done := state === S.Done
 
   fft.in.bits.real := DontCare
   fft.in.bits.imag := DontCare

--- a/src/test/scala/esptests/examples/FFTAcceleratorSpec.scala
+++ b/src/test/scala/esptests/examples/FFTAcceleratorSpec.scala
@@ -188,6 +188,9 @@ class FFTAcceleratorSpec extends FlatSpec with ChiselScalatestTester with Matche
             }
           }
 
+          dut.io.done.expect(true.B)
+          dut.io.debug.expect(0.U)
+
         }
     }
   }


### PR DESCRIPTION
This fixes a bug where the FFTAccelerator always asserts it's done line. This should be tied to the done state.