### PR TITLE
Fix incorrect DMA read/write length

### DIFF
--- a/src/main/scala/esp/examples/FFTAccelerator.scala
+++ b/src/main/scala/esp/examples/FFTAccelerator.scala
@@ -176,7 +176,7 @@ class FFTAccelerator[A <: Data : Real : BinaryRepresentation](dmaWidth: Int, val
   when (state === S.DMALoad) {
     io.dma.readControl.valid := ~dmaRead.valid
     io.dma.readControl.bits.index := addr
-    io.dma.readControl.bits.length := stride * count
+    io.dma.readControl.bits.length := stride * count * 2
 
     when (io.dma.readControl.fire) {
       dmaRead.valid := true.B
@@ -200,7 +200,7 @@ class FFTAccelerator[A <: Data : Real : BinaryRepresentation](dmaWidth: Int, val
   when (state === S.DMAStore) {
     io.dma.writeControl.valid := ~dmaWrite.valid
     io.dma.writeControl.bits.index := addr
-    io.dma.writeControl.bits.length := stride * count
+    io.dma.writeControl.bits.length := stride * count * 2
 
     when (io.dma.writeControl.fire) {
       dmaWrite.valid := true.B

--- a/src/test/scala/esptests/examples/FFTAcceleratorSpec.scala
+++ b/src/test/scala/esptests/examples/FFTAcceleratorSpec.scala
@@ -152,7 +152,8 @@ class FFTAcceleratorSpec extends FlatSpec with ChiselScalatestTester with Matche
 
           dut.io.enable.poke(false.B)
 
-          dut.io.dma.readControl.expectDequeue((new DmaControl).Lit(_.index -> 0.U, _.length -> numPoints.U, _.size -> DmaSize.word))
+          dut.io.dma.readControl
+            .expectDequeue((new DmaControl).Lit(_.index -> 0.U, _.length -> (numPoints * 2).U, _.size -> DmaSize.word))
 
           {
             val inputx = input
@@ -164,7 +165,8 @@ class FFTAcceleratorSpec extends FlatSpec with ChiselScalatestTester with Matche
             dut.io.dma.readChannel.enqueueSeq(inputx)
           }
 
-          dut.io.dma.writeControl.expectDequeue((new DmaControl).Lit(_.index -> 0.U, _.length -> numPoints.U, _.size -> DmaSize.word))
+          dut.io.dma.writeControl
+            .expectDequeue((new DmaControl).Lit(_.index -> 0.U, _.length -> (numPoints * 2).U, _.size -> DmaSize.word))
 
           {
             val outputx = output


### PR DESCRIPTION
This fixes an off-by-2x bug where the DMA read/write length needs to be 2x larger to include all real and imaginary components.

Fixes #34. I screwed this up in both the accelerator *and* the test. Fixed in both with this PR.
