### PR TITLE
Fix naming for FFT, use FFT architecture in name

### DIFF
--- a/src/main/scala/esp/AcceleratorWrapper.scala
+++ b/src/main/scala/esp/AcceleratorWrapper.scala
@@ -68,7 +68,7 @@ trait AcceleratorWrapperIO { this: RawModule =>
   */
 final class AcceleratorWrapper(val dmaWidth: Int, gen: Int => Implementation) extends RawModule with AcceleratorWrapperIO {
 
-  override lazy val desiredName = s"${acc.config.name}_${acc.implementationName}"
+  override lazy val desiredName = s"${acc.config.name}_${acc.implementationName}_dma$dmaWidth"
   val acc = withClockAndReset(clk, ~rst)(Module(gen(dmaWidth)))
 
   val conf_info = acc.io.config.map(a => IO(Input(a.cloneType)))

--- a/src/main/scala/esp/Generator.scala
+++ b/src/main/scala/esp/Generator.scala
@@ -23,7 +23,7 @@ object Generator {
   def main(args: Array[String]): Unit = {
     val examples: Seq[(String, String, () => AcceleratorWrapper)] =
       Seq( ("CounterAccelerator", "Default", (a: Int) => new CounterAccelerator(a)),
-           ("FFTAccelerator", "Default", (a: Int) => new DefaultFFTAccelerator(a)) )
+           ("FFTAccelerator", DefaultFFTAccelerator.architecture, (a: Int) => new DefaultFFTAccelerator(a)) )
         .flatMap( a => Seq(32).map(b => (a._1, s"${a._2}_dma$b", () => new AcceleratorWrapper(b, a._3))) )
 
     examples.map { case (name, impl, gen) =>

--- a/src/main/scala/esp/examples/CounterAccelerator.scala
+++ b/src/main/scala/esp/examples/CounterAccelerator.scala
@@ -50,7 +50,7 @@ trait CounterSpecification extends Specification {
 
 class CounterAccelerator(dmaWidth: Int) extends Implementation(dmaWidth) with CounterSpecification {
 
-  override val implementationName: String = "Default_dma" + dmaWidth
+  override val implementationName: String = "Default"
 
   val ticks, value = Reg(UInt(config.paramMap("ticks").size.W))
   val enabled = RegInit(false.B)

--- a/src/test/scala/esptests/AcceleratorWrapperSpec.scala
+++ b/src/test/scala/esptests/AcceleratorWrapperSpec.scala
@@ -75,7 +75,7 @@ class AcceleratorWrapperSpec extends FlatSpec with Matchers {
                    () => new AcceleratorWrapper(32, (a: Int) => new BarImplementation(a)))
 
     val expectedIO = collectVerilogIO(Source.fromFile("src/main/resources/esp_acc_iface.v").getLines.toSeq)
-    val generatedIO = collectVerilogIO(Source.fromFile(s"$targetDir/foo_bar.v").getLines.toSeq).toSet
+    val generatedIO = collectVerilogIO(Source.fromFile(s"$targetDir/foo_bar_dma32.v").getLines.toSeq).toSet
 
     for (g <- expectedIO) {
       info(s"Contains: ${g.serialize}")


### PR DESCRIPTION
This changes how the name is generated for accelerator implementations in the following ways:

1. The `implementationName` is now used as a replacement for the `Default` string. 
2. The `dma$width` is now derived from the parameter used to set the DMA width
3. The FFT accelerator now uses a very descriptive name for `implementationName`

In effect, where the FFT accelerator was previously called `FFTAccelerator_Default_fft32`, it is now `FFTAccelerator_32PointFP32p20SDF_dma32`. @paulmnt: Can you confirm that this is alright for a name?

Fixes #33.