### PR TITLE
Set FFT memory footprint to 1MB

### DIFF
--- a/src/main/scala/esp/examples/FFTAccelerator.scala
+++ b/src/main/scala/esp/examples/FFTAccelerator.scala
@@ -50,7 +50,7 @@ trait FFTSpecification extends Specification {
     description = params.protoIQ.real match {
       case a: FixedPoint => s"${params.numPoints}-point ${a.getWidth}.${a.binaryPoint.get} FFT"
     },
-    memoryFootprintMiB = 0,
+    memoryFootprintMiB = 1,
     deviceId = 0xD,
     param = Array(
       Parameter(


### PR DESCRIPTION
This sets the memory footprint of the FFT accelerator from 0MB to 1MB.
Currently, the implementation needs far less (only 256B) due to it's
fixed nature of one 32-point 32.20 fixed point FFT.

This will need to be changed later on as the microarchitecture is
updated.

Fixes #32.