### PR TITLE
Adder example

### DIFF
--- a/src/main/scala/esp/Generator.scala
+++ b/src/main/scala/esp/Generator.scala
@@ -16,14 +16,15 @@ package esp
 
 import chisel3.Driver
 
-import esp.examples.{CounterAccelerator, DefaultFFTAccelerator}
+import esp.examples.{AdderAccelerator, CounterAccelerator, DefaultFFTAccelerator}
 
 object Generator {
 
   def main(args: Array[String]): Unit = {
     val examples: Seq[(String, String, () => AcceleratorWrapper)] =
       Seq( ("CounterAccelerator", "Default", (a: Int) => new CounterAccelerator(a)),
-           ("FFTAccelerator", DefaultFFTAccelerator.architecture, (a: Int) => new DefaultFFTAccelerator(a)) )
+           ("FFTAccelerator", DefaultFFTAccelerator.architecture, (a: Int) => new DefaultFFTAccelerator(a)),
+           ("AdderAccelerator", "Default", (a: Int) => new AdderAccelerator(a) ))
         .flatMap( a => Seq(32).map(b => (a._1, s"${a._2}_dma$b", () => new AcceleratorWrapper(b, a._3))) )
 
     examples.map { case (name, impl, gen) =>

--- a/src/main/scala/esp/examples/AdderAccelerator.scala
+++ b/src/main/scala/esp/examples/AdderAccelerator.scala
@@ -1,0 +1,121 @@
+// Copyright 2018-2019 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esp.examples
+
+import chisel3._
+import chisel3.experimental.ChiselEnum
+
+import esp.{Config, Implementation, Parameter, Specification}
+
+trait AdderSpecification extends Specification {
+
+  override lazy val config = Config(
+    name = "AdderAccelerator",
+    description = "Reduces a vector via addition",
+    memoryFootprintMiB = 1,
+    deviceId = 0xF,
+    param = Array(
+      Parameter( name = "readAddr" ),
+      Parameter( name = "size" ),
+      Parameter( name = "writeAddr" )
+    )
+  )
+
+}
+
+object AdderAccelerator {
+
+  private object S extends ChiselEnum {
+    val Idle, DMALoad, Compute, DMAStore, Done = Value
+  }
+
+  /** FFTAccelerator error codes */
+  object Errors extends ChiselEnum {
+    val None = Value(0.U)
+    val InvalidSize, Unimplemented = Value
+  }
+
+}
+
+class AdderAccelerator(dmaWidth: Int) extends Implementation(dmaWidth) with AdderSpecification {
+  require(dmaWidth == 32)
+
+  import AdderAccelerator._
+
+  override val implementationName = "AdderAccelerator"
+
+  private val readAddr, size, writeAddr = Reg(UInt(32.W))
+
+  private val state = RegInit(S.Idle)
+
+  private val acc, count = Reg(UInt(32.W))
+
+  private val storeReqSent = RegInit(false.B)
+
+  when (io.enable && state === S.Idle) {
+    Seq((readAddr, "readAddr"), (size, "size"), (writeAddr, "writeAddr")).foreach{
+      case (lhs, name) => lhs := io.config.get(name).asUInt
+    }
+    when (io.config.get("size").asUInt === 0.U) {
+      state := S.DMAStore
+    }.otherwise {
+      state := S.DMALoad
+    }
+    acc := 0.U
+    count := 0.U
+    storeReqSent := false.B
+  }
+
+  when (state === S.DMALoad) {
+    io.dma.readControl.valid := true.B
+    io.dma.readControl.bits.index := readAddr
+    io.dma.readControl.bits.length := size
+    when (io.dma.readControl.fire) {
+      state := S.Compute
+    }
+  }
+
+  when (state === S.Compute) {
+    io.dma.readChannel.ready := true.B
+    when (io.dma.readChannel.fire) {
+      acc := acc + io.dma.readChannel.bits
+      count := count + (dmaWidth / 32).U
+      when (count === size - 1.U) {
+        state := S.DMAStore
+      }
+    }
+  }
+
+  when (state === S.DMAStore) {
+    io.dma.writeChannel.bits := acc
+    when (storeReqSent =/= true.B) {
+      io.dma.writeControl.valid := true.B
+      io.dma.writeControl.bits.index := writeAddr
+      io.dma.writeControl.bits.length := 1.U
+      storeReqSent := io.dma.writeControl.fire
+    }.otherwise {
+      io.dma.writeChannel.valid := true.B
+      when (io.dma.writeChannel.fire) {
+        state := S.Done
+      }
+    }
+  }
+
+  when (state === S.Done) {
+    io.done := true.B
+    state := S.Idle
+  }
+
+}

--- a/src/test/scala/esptests/AcceleratorSpec.scala
+++ b/src/test/scala/esptests/AcceleratorSpec.scala
@@ -1,0 +1,37 @@
+// Copyright 2018-2019 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esptests
+
+import esp.Implementation
+
+import chisel3._
+import chisel3.tester._
+
+object AcceleratorSpec {
+
+  implicit class AcceleratorHelpers[A <: Implementation](dut: A) {
+    def doReset() = {
+      dut.reset.poke(true.B)
+      dut.io.enable.poke(false.B)
+      dut.io.dma.readControl.ready.poke(false.B)
+      dut.io.dma.writeControl.ready.poke(false.B)
+      dut.io.dma.readChannel.valid.poke(false.B)
+      dut.io.dma.writeChannel.ready.poke(false.B)
+      dut.clock.step(1)
+      dut.reset.poke(false.B)
+    }
+  }
+
+}

--- a/src/test/scala/esptests/examples/AdderAcceleratorSpec.scala
+++ b/src/test/scala/esptests/examples/AdderAcceleratorSpec.scala
@@ -1,0 +1,80 @@
+// Copyright 2018-2019 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esptests.examples
+
+import chisel3._
+import chisel3.experimental.BundleLiterals._
+import chisel3.tester._
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import esp.{DmaControl, DmaSize}
+import esp.examples.AdderAccelerator
+
+import esptests.AcceleratorSpec._
+
+class AdderAcceleratorSpec extends FlatSpec with ChiselScalatestTester with Matchers {
+
+  behavior of "AdderAccelerator"
+
+  private def adderTest(input: Seq[Int], readAddr: Int = 0, writeAddr: Int = 0) = {
+    val expectedOutput = input.foldLeft(0){ case (acc, x) => acc + x }
+    it should s"""reduce [${input.mkString(",")}] to ${expectedOutput}""" in {
+      test(new AdderAccelerator(32)) { dut =>
+
+        dut.doReset()
+
+        dut.io.dma.readControl.initSink().setSinkClock(dut.clock)
+        dut.io.dma.readChannel.initSource().setSourceClock(dut.clock)
+        dut.io.dma.writeControl.initSink().setSinkClock(dut.clock)
+        dut.io.dma.writeChannel.initSink().setSinkClock(dut.clock)
+
+        timescope {
+          dut.io.config.get("readAddr").poke(readAddr.U)
+          dut.io.config.get("size").poke(input.length.U)
+          dut.io.config.get("writeAddr").poke(writeAddr.U)
+          dut.io.enable.poke(true.B)
+          dut.clock.step()
+        }
+
+        input.length match {
+          case 0 =>
+          case _ =>
+            dut.io.dma.readControl
+              .expectDequeue((new DmaControl).Lit(_.index -> readAddr.U, _.length -> input.length.U, _.size -> DmaSize.word))
+            dut.io.dma.readChannel.enqueueSeq(input.map(_.U))
+        }
+
+        dut.io.dma.writeControl
+          .expectDequeue((new DmaControl).Lit(_.index -> writeAddr.U, _.length -> 1.U, _.size -> DmaSize.word))
+
+        dut.io.dma.writeChannel
+          .expectDequeue(input.foldLeft(0){ case (acc, x) => acc + x }.U)
+
+        dut.io.done.expect(true.B)
+
+      }
+    }
+
+  }
+
+  Seq( Seq.empty[Int],
+       Seq(0),
+       Seq(1),
+       Seq(1, 2, 3),
+       Seq(100, 200, 300, 400, 500, 600, 700, 800, 900, 1000))
+    .foreach(adderTest(_))
+
+}


### PR DESCRIPTION
This includes a new example accelerator, `AdderAccelerator`, that does a `foldLeft` addition reduction on a sequential memory range.

This is intended to be the running example in the FOSDEM talk.